### PR TITLE
improve list traversal performance and fix fd leaks

### DIFF
--- a/src/bootchart.c
+++ b/src/bootchart.c
@@ -40,7 +40,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/resource.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -320,7 +319,6 @@ int main(int argc, char *argv[]) {
         time_t t = 0;
         int r, samples;
         struct ps_struct *ps;
-        struct rlimit rlim;
         struct list_sample_data *head;
         struct sigaction sig = {
                 .sa_handler = signal_handler,
@@ -347,10 +345,6 @@ int main(int argc, char *argv[]) {
                         execl(arg_init_path, arg_init_path, NULL);
         }
         argv[0][0] = '@';
-
-        rlim.rlim_cur = 4096;
-        rlim.rlim_max = 4096;
-        (void) setrlimit(RLIMIT_NOFILE, &rlim);
 
         schfd = open("/proc/sys/kernel/sched_schedstats", O_WRONLY);
         if (schfd >= 0) {
@@ -463,8 +457,8 @@ int main(int argc, char *argv[]) {
 
         /* do some cleanup, close fd's */
         ps = ps_first;
-        while (ps->next_ps) {
-                ps = ps->next_ps;
+        while (ps->next_running) {
+                ps = ps->next_running;
                 ps->schedstat = safe_close(ps->schedstat);
                 ps->sched = safe_close(ps->sched);
                 ps->smaps = safe_fclose(ps->smaps);

--- a/src/bootchart.h
+++ b/src/bootchart.h
@@ -66,10 +66,11 @@ struct list_sample_data {
 
 /* process info */
 struct ps_struct {
-        struct ps_struct *next_ps;    /* SLL pointer */
-        struct ps_struct *parent;     /* ppid ref */
-        struct ps_struct *children;   /* children */
-        struct ps_struct *next;       /* siblings */
+        struct ps_struct *next_ps;      /* SLL pointer */
+        struct ps_struct *next_running; /* currently running */
+        struct ps_struct *parent;       /* ppid ref */
+        struct ps_struct *children;     /* children */
+        struct ps_struct *next;         /* siblings */
 
         /* must match - otherwise it's a new process with same PID */
         char name[256];
@@ -81,6 +82,9 @@ struct ps_struct {
         int sched;
         int schedstat;
         FILE *smaps;
+
+        /* used to garbage collect running process list*/
+        bool still_running;
 
         /* pointers to first/last seen timestamps */
         struct ps_sched_struct *first;


### PR DESCRIPTION
This fixes the file descriptor leaks. It also has the added bonus of improving overall performance, since the whole list of processes doesn't need to be traversed for each process at each sample point.
This resolves #25