### PR TITLE
don't waste time checking for hidden files

### DIFF
--- a/src/dirent-util.c
+++ b/src/dirent-util.c
@@ -29,8 +29,5 @@ bool dirent_is_file_with_suffix(const struct dirent *de, const char *suffix) {
             de->d_type != DT_UNKNOWN)
                 return false;
 
-        if (hidden_file_allow_backup(de->d_name))
-                return false;
-
         return endswith(de->d_name, suffix);
 }

--- a/src/dirent-util.h
+++ b/src/dirent-util.h
@@ -35,15 +35,4 @@ bool dirent_is_file_with_suffix(const struct dirent *de, const char *suffix) _pu
                                 on_error;                               \
                         }                                               \
                         break;                                          \
-                } else if (hidden_file((de)->d_name))                   \
-                        continue;                                       \
-                else
-
-#define FOREACH_DIRENT_ALL(de, d, on_error)                             \
-        for (errno = 0, de = readdir(d);; errno = 0, de = readdir(d))   \
-                if (!de) {                                              \
-                        if (errno > 0) {                                \
-                                on_error;                               \
-                        }                                               \
-                        break;                                          \
                 } else

--- a/src/path-util.c
+++ b/src/path-util.c
@@ -272,33 +272,3 @@ char *file_in_same_dir(const char *path, const char *filename) {
         memcpy(mempcpy(ret, path, e + 1 - path), filename, k + 1);
         return ret;
 }
-
-bool hidden_file_allow_backup(const char *filename) {
-        assert(filename);
-
-        return
-                filename[0] == '.' ||
-                streq(filename, "lost+found") ||
-                streq(filename, "aquota.user") ||
-                streq(filename, "aquota.group") ||
-                endswith(filename, ".rpmnew") ||
-                endswith(filename, ".rpmsave") ||
-                endswith(filename, ".rpmorig") ||
-                endswith(filename, ".dpkg-old") ||
-                endswith(filename, ".dpkg-new") ||
-                endswith(filename, ".dpkg-tmp") ||
-                endswith(filename, ".dpkg-dist") ||
-                endswith(filename, ".dpkg-bak") ||
-                endswith(filename, ".dpkg-backup") ||
-                endswith(filename, ".dpkg-remove") ||
-                endswith(filename, ".swp");
-}
-
-bool hidden_file(const char *filename) {
-        assert(filename);
-
-        if (endswith(filename, "~"))
-                return true;
-
-        return hidden_file_allow_backup(filename);
-}

--- a/src/path-util.h
+++ b/src/path-util.h
@@ -80,6 +80,3 @@ char** path_strv_resolve_uniq(char **l, const char *prefix);
         })
 
 char *file_in_same_dir(const char *path, const char *filename);
-
-bool hidden_file_allow_backup(const char *filename);
-bool hidden_file(const char *filename) _pure_;


### PR DESCRIPTION
When profiling bootchart under callgrind, I noticed that a lot of time was spent in the `hidden_file` function when looping over directory entries. This call is unnecessary since we always use check the name of the file anyways.