### PR TITLE
Add tests & support using travis for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: c
+sudo: false
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'intltool', 'gcc-7' ]
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CFLAGS='-fno-omit-frame-pointer -fsanitize=undefined -fsanitize=address -ggdb3 -fvar-tracking-assignments -Og'"
+
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
+          packages: [ 'intltool', 'clang-4.0']
+      env:
+        - MATRIX_EVAL="CC=clang-4.0 && CFLAGS='-fno-omit-frame-pointer -fsanitize=undefined -fsanitize=address -ggdb3 -fvar-tracking-assignments -Og'"
+
+script:
+  - eval "${MATRIX_EVAL}"
+  - ./autogen.sh && ./configure --without-libsystemd --disable-man && make -j2 && make -j2 -k check
+
+after_failure:
+  - cat config.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -192,6 +192,8 @@ systemd_bootchart_LDADD = \
 
 #####################################################
 
+TESTS = tests/run
+
 substitutions = \
 	'|rootlibexecdir=$(rootlibexecdir)|'
 

--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,7 @@ AC_SUBST([rootprefix], [$with_rootprefix])
 AC_SUBST([rootlibdir], [$with_rootlibdir])
 
 AC_ARG_ENABLE([man],
-        AS_HELP_STRING([--diable-man],[Build the man pages (default: yes)]),
+        AS_HELP_STRING([--disable-man],[Build the man pages (default: yes)]),
         [build_man=$enableval],
         [build_man=yes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -62,8 +62,16 @@ AC_CHECK_DECLS([gettid, getrandom], [], [], [[
 #include <linux/random.h>
 ]])
 
-PKG_CHECK_MODULES(LIBSYSTEMD, [libsystemd >= 221],
-	[], [AC_MSG_ERROR([*** libsystemd library not found])])
+AC_ARG_WITH(libsystemd,
+        AS_HELP_STRING([--without-libsystemd], [Disable use of libsystemd for journal output]),
+        [], [with_libsystemd=yes])
+
+AS_IF([test "x$with_libsystemd" != xno],
+        [PKG_CHECK_MODULES(LIBSYSTEMD, [libsystemd >= 221],
+                [AC_DEFINE([HAVE_LIBSYSTEMD],[1],[Define if you have libsystemd])],
+                [AC_MSG_ERROR([*** libsystemd library not found])]
+        )]
+)
 
 CC_CHECK_FLAGS_APPEND([with_cflags], [CFLAGS], [\
         -pipe \

--- a/src/bootchart.c
+++ b/src/bootchart.c
@@ -505,7 +505,7 @@ int main(int argc, char *argv[]) {
 
         /* nitpic cleanups */
         ps = ps_first->next_ps;
-        while (ps->next_ps) {
+        while (ps) {
                 struct ps_struct *old;
 
                 old = ps;
@@ -522,9 +522,6 @@ int main(int argc, char *argv[]) {
                 free(old);
         }
 
-        free(ps->cgroup);
-        free(ps->sample);
-        free(ps);
         free(ps_first);
 
         sampledata = head;

--- a/src/bootchart.c
+++ b/src/bootchart.c
@@ -525,6 +525,7 @@ int main(int argc, char *argv[]) {
         free(ps->cgroup);
         free(ps->sample);
         free(ps);
+        free(ps_first);
 
         sampledata = head;
         while (sampledata->link_prev) {

--- a/src/bootchart.c
+++ b/src/bootchart.c
@@ -45,7 +45,9 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-journal.h>
+#endif
 
 #include "alloc-util.h"
 #include "bootchart.h"
@@ -258,6 +260,7 @@ static int parse_argv(int argc, char *argv[]) {
 }
 
 static int do_journal_append(char *file) {
+#ifdef HAVE_LIBSYSTEMD
         _cleanup_free_ char *bootchart_message = NULL;
         _cleanup_free_ char *bootchart_file = NULL;
         _cleanup_free_ char *p = NULL;
@@ -301,6 +304,9 @@ static int do_journal_append(char *file) {
         if (r < 0)
                 log_error_errno(r, "Failed to send bootchart: %m");
 
+#else
+        (void)file;
+#endif
         return 0;
 }
 

--- a/src/bootchart.c
+++ b/src/bootchart.c
@@ -525,9 +525,9 @@ int main(int argc, char *argv[]) {
         free(ps_first);
 
         sampledata = head;
-        while (sampledata->link_prev) {
+        while (sampledata->link_next) {
                 struct list_sample_data *old_sampledata = sampledata;
-                sampledata = sampledata->link_prev;
+                sampledata = sampledata->link_next;
                 free(old_sampledata);
         }
         free(sampledata);

--- a/src/log.c
+++ b/src/log.c
@@ -323,7 +323,9 @@ int log_syntax_internal(
         r = log_struct_internal(
                         level, error,
                         file, line, func,
+#ifdef HAVE_LIBSYSTEMD
                         LOG_MESSAGE_ID(SD_MESSAGE_INVALID_CONFIGURATION),
+#endif
                         "CONFIG_FILE=%s", config_file,
                         "CONFIG_LINE=%u", config_line,
                         LOG_MESSAGE("[%s:%u] %s", config_file, config_line, buffer),

--- a/src/log.h
+++ b/src/log.h
@@ -24,8 +24,6 @@
 #include <stdlib.h>
 #include <syslog.h>
 
-#include <systemd/sd-id128.h>
-
 #include "alloc-util.h"
 #include "attributes.h"
 

--- a/src/sd-messages.h
+++ b/src/sd-messages.h
@@ -20,6 +20,7 @@
   along with systemd; If not, see <http://www.gnu.org/licenses/>.
 ***/
 
+#ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-id128.h>
 
 #include "_sd-common.h"
@@ -30,5 +31,6 @@ _SD_BEGIN_DECLARATIONS;
 #define SD_MESSAGE_BOOTCHART             SD_ID128_MAKE(9f,26,aa,56,2c,f4,40,c2,b1,6c,77,3d,04,79,b5,18)
 
 _SD_END_DECLARATIONS;
+#endif
 
 #endif

--- a/src/store.c
+++ b/src/store.c
@@ -366,17 +366,15 @@ no_sched:
 
                         ps->parent = parent;
 
-                        if (!parent->children) {
-                                /* it's the first child */
-                                parent->children = ps;
-                        } else {
-                                /* walk all children and append */
-                                struct ps_struct *children;
-                                children = parent->children;
-                                while (children->next)
-                                        children = children->next;
-
-                                children->next = ps;
+                        /*
+                         * append ourselves to the list of children
+                         * TODO: consider if prepending is OK for efficiency here.
+                         */
+                        {
+                                struct ps_struct **children = &parent->children;
+                                while (*children)
+                                        children = &(*children)->next;
+                                *children = ps;
                         }
                 }
 

--- a/src/store.c
+++ b/src/store.c
@@ -106,8 +106,10 @@ static void garbage_collect_dead_processes(struct ps_struct *ps_first) {
                         /* close the stream and fds */
                         ps_next->schedstat = safe_close(ps_next->schedstat);
                         ps_next->sched = safe_close(ps_next->sched);
-                        if (ps->smaps)
-                                fclose(ps->smaps);
+                        if (ps_next->smaps) {
+                                fclose(ps_next->smaps);
+                                ps_next->smaps = NULL;
+                        }
 
                         ps->next_running = ps_next->next_running;
                 } else {

--- a/src/store.c
+++ b/src/store.c
@@ -258,11 +258,19 @@ schedstat_next:
                         char t[32];
                         struct ps_struct *parent;
 
-                        ps->next_ps = ps->next_running = new0(struct ps_struct, 1);
-                        if (!ps->next_ps)
+                        /* find the insertion point for the last item */
+                        struct ps_struct **ps_next = &ps->next_ps;
+                        while (*ps_next) {
+                                ps_next = &(*ps_next)->next_ps;
+                        }
+
+                        assert(!*ps_next);
+                        assert(!ps->next_running);
+                        *ps_next = ps->next_running = new0(struct ps_struct, 1);
+                        if (!*ps_next)
                                 return log_oom();
 
-                        ps = ps->next_ps;
+                        ps = *ps_next;
                         ps->pid = pid;
                         ps->sched = -1;
                         ps->schedstat = -1;

--- a/tests/run
+++ b/tests/run
@@ -1,0 +1,33 @@
+#! /bin/sh
+d=
+cleanup() {
+        if [ -n "$d" ]; then
+                d=
+                rm -rf "$d"
+        fi
+}
+trap cleanup EXIT
+d=`mktemp -d`
+
+test_runs=0
+test_failures=0
+
+t() {
+        "$@"
+        local r=$?
+        : $((test_runs=test_runs+1))
+        if [ $r -ne 0 ]; then
+                : $((test_failures=test_failures+1))
+                echo "not ok $test_runs - $*"
+        fi
+}
+
+echo 1..3
+t ./systemd-bootchart -o "$d" -n 2 -r
+t ./systemd-bootchart -o "$d" -n 10 -r
+t ./systemd-bootchart -o "$d" -n 10 -r -p
+
+if [ $test_failures -ne 0 ]; then
+        echo "# Failed $test_failures out of $test_runs tests"
+        exit 1
+fi


### PR DESCRIPTION
This extends #32 and:

 - fixes some remaining memory leaks
 - allows building systemd-bootchart without having libsystemd (helps with travis)
 - adds a simple test which runs systemd-bootchart a few times, hooked up to `make check`
 - Adds configuration to run and test using clang-4.0 & gcc-7 on travis, and enables asan & ubsan.

On extending this later: We likely need some more deterministic testing, so I've got a few changes I'm also working on which allow using custom locations for /proc and /sys, and another which tries adding a test which works with a series of snapshots of /proc.