### PR TITLE
parse-util: Don't use xlocale.h

### DIFF
--- a/src/parse-util.c
+++ b/src/parse-util.c
@@ -21,7 +21,6 @@
 #include <locale.h>
 #include <stdlib.h>
 #include <string.h>
-#include <xlocale.h>
 
 #include "macro.h"
 #include "parse-util.h"


### PR DESCRIPTION
glibc 2.26 no longer contains the non-standard xlocale.h
(http://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27)

This change shouldn't break anything as xlocale.h was a subset of
locale.h.