### PR TITLE
Minor man page updates

### DIFF
--- a/man/systemd-bootchart.xml
+++ b/man/systemd-bootchart.xml
@@ -260,7 +260,7 @@
     in most browsers (including Chrome and Firefox) are many times
     faster than dedicated graphical applications like Gimp and
     Inkscape. Just point your browser at
-    <ulink url="file:///run/log/" />!
+    <ulink url="file:///run/log/" /> (the default location).
     </para>
   </refsect1>
 
@@ -324,10 +324,12 @@
     <code>root=/dev/sdxY</code>. Using UUIDs or PARTUUIDs will boot
     fine, but the hard drive model will not be added to the
     chart.</para>
-    <para>For bugs, please contact the author and current maintainer:</para>
+    <para>If you encounter a bug, then please open an issue on GitHub:</para>
     <simplelist>
-      <member>Auke Kok <email>auke-jan.h.kok@intel.com</email></member>
+      <member><ulink url="https://github.com/systemd/systemd-bootchart" /></member>
     </simplelist>
+    <para>The community thanks Auke Kok, the original author and maintainer
+    of systemd-bootchart.</para>
   </refsect1>
 
 </refentry>

--- a/units/systemd-bootchart.service.in
+++ b/units/systemd-bootchart.service.in
@@ -10,7 +10,7 @@
 
 [Unit]
 Description=Boot Process Profiler
-Documentation=man:systemd-bootchart.service(1) man:bootchart.conf(5)
+Documentation=man:systemd-bootchart(1) man:bootchart.conf(5)
 DefaultDependencies=no
 
 [Service]


### PR DESCRIPTION
Auke K's intel email is no longer valid.  Drop it and instead point users to the GitHub project page.

Also, fix a bad man page reference inside systemd-bootchart.service (Fixes #43).