### PR TITLE
tests: fix cleanup

### DIFF
--- a/tests/run
+++ b/tests/run
@@ -2,8 +2,8 @@
 d=
 cleanup() {
         if [ -n "$d" ]; then
-                d=
                 rm -rf "$d"
+                d=
         fi
 }
 trap cleanup EXIT


### PR DESCRIPTION
The cleanup routine cleared the variable holding the temp dir name before it was deleted, so it wasn't deleted.

This commit first deletes the temp folder, and clears the variable afterwards.